### PR TITLE
A small change to allow nose attrs to be passed down iterative tests

### DIFF
--- a/j5test/IterativeTester.py
+++ b/j5test/IterativeTester.py
@@ -103,6 +103,10 @@ class IterativeTester(with_metaclass(IterativeTesterMetaClass, object)):
         newmeth.__dict__ = oldmeth.__dict__.copy()
         newmeth.iterativetestprefix = prefix
         newmeth.iterativetestvarnames = varnames
+        for k in dir(oldmeth):
+            if not k.startswith("__"):
+                setattr(newmeth, k, getattr(oldmeth, k))
+
 
         setattr(cls,newname,newmeth)
 


### PR DESCRIPTION
Nose has a nice construct in nose.plugins.attrib which allows labelling of tests so you can run distinct sets. I have been updating my py3 branch with the Hexagon standard of l1 for fast tests, l2 for slower tests, l3 for long tests (and theoretically at some stage l4 for smoketests). But our IterativeTest maker doesn't support the attribs, because it doesn't pass down the attrs to the created test methods.

This small change makes sure any attribs are copied across in the creation of the iterative tests.