### PR TITLE
Futurize broke using only_thread_blocking without specifying block_name

### DIFF
--- a/j5test/ThreadWeave.py
+++ b/j5test/ThreadWeave.py
@@ -25,15 +25,9 @@ def only_thread(thread_name):
         raise WithContextSkip.SkipStatement()
 
 @WithContextSkip.conditionalcontextmanager
-def only_thread_blocking(thread_name, block_name=None):
+def only_thread_blocking(thread_name, block_name):
     """Runs the controlled block only if the current thread has the given name - otherwise skips it. Wait for the given thread to run the block before allowing other threads to proceed"""
     with block_event_lock:
-        if block_name is None:
-            frame = sys._getframe().f_back.f_back
-            filename = frame.f_code.co_filename
-            if filename.startswith("<"):
-                filename = filename + "/0x%x" % id(frame.f_code)
-            block_name = "%s:%d" % (filename, frame.f_lineno)
         block_event = block_events.setdefault(block_name, threading.Event())
     current_thread_name = threading.current_thread().name
     if thread_name == current_thread_name:

--- a/j5test/test_ThreadWeave.py
+++ b/j5test/test_ThreadWeave.py
@@ -112,11 +112,11 @@ class TestBlockingWeave(object):
         """A method that can be entered by multiple threads, and decides what to do as it processes the queue depending on which thread is active, blocking the others along the way"""
         with ThreadWeave.only_thread_blocking('eat_fries', 'first_fries') as StatementSkipped.detector:
             self.eat_fries(name)
-        with ThreadWeave.only_thread_blocking('eat_burgers') as StatementSkipped.detector:
+        with ThreadWeave.only_thread_blocking('eat_burgers', 'first_burger') as StatementSkipped.detector:
             self.eat_burgers(name)
-        with ThreadWeave.only_thread_blocking('eat_fries') as StatementSkipped.detector:
+        with ThreadWeave.only_thread_blocking('eat_fries', 'second_fries') as StatementSkipped.detector:
             self.eat_fries(name)
-        with ThreadWeave.only_thread_blocking('eat_burgers') as StatementSkipped.detector:
+        with ThreadWeave.only_thread_blocking('eat_burgers', 'second_burger') as StatementSkipped.detector:
             self.eat_burgers(name)
         with ThreadWeave.only_thread_blocking('eat_fries', 'third_fries') as StatementSkipped.detector:
             self.eat_fries(name)


### PR DESCRIPTION
To determine what line of code was being run, only_thread_blocking
walked up the stack frame using .f_back.f_back. However, futurize put a
shim in between making the offset incorrect.

The simplest solution is to force people to specify a unique block name
instead of trying to generate one automatically.